### PR TITLE
fix: header not showing in storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,6 +5,8 @@ import addons from '@storybook/addons'
 
 import '../src/components/layout.css';
 
+global.__BASE_PATH__ = '';
+
 // get an instance to the communication channel for the manager and preview
 const channel = addons.getChannel()
 


### PR DESCRIPTION
fixed by https://github.com/gatsbyjs/gatsby/issues/10668#issuecomment-639014099